### PR TITLE
Bugfix/i os10 data compatibility

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		30D40F922084876100DC126F /* MeshModelIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30D40F912084876000DC126F /* MeshModelIdentifiers.swift */; };
 		30D40F94208487D600DC126F /* MeshVendorModelIdentifierStringConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30D40F93208487D600DC126F /* MeshVendorModelIdentifierStringConverter.swift */; };
 		30D40F9920849C4A00DC126F /* CompanyIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30D40F9820849C4A00DC126F /* CompanyIdentifiers.swift */; };
+		30FF5ED8209314DA002D7C77 /* DefaultTTLGetMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30FF5ED7209314DA002D7C77 /* DefaultTTLGetMessage.swift */; };
+		30FF5EDA20931587002D7C77 /* DefaultTTLGetConfiguratorState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30FF5ED920931587002D7C77 /* DefaultTTLGetConfiguratorState.swift */; };
 		32F4A650C11D581F50F1C04437EBA6A7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93972F6957789C9E8A0EFA25275C82D1 /* Foundation.framework */; };
 		35304939BAC356B98D33C2FD8FF3033B /* LowerTransportPDUParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 717AE9407031C7B2A506444276B65C58 /* LowerTransportPDUParams.swift */; };
 		3AE15C3450EEAE497500156AF4B1C428 /* CompositionElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BE8FB861139283C753A8A8C3E6E3F73 /* CompositionElement.swift */; };
@@ -143,6 +145,8 @@
 		30D40F912084876000DC126F /* MeshModelIdentifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeshModelIdentifiers.swift; sourceTree = "<group>"; };
 		30D40F93208487D600DC126F /* MeshVendorModelIdentifierStringConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeshVendorModelIdentifierStringConverter.swift; sourceTree = "<group>"; };
 		30D40F9820849C4A00DC126F /* CompanyIdentifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompanyIdentifiers.swift; sourceTree = "<group>"; };
+		30FF5ED7209314DA002D7C77 /* DefaultTTLGetMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTTLGetMessage.swift; sourceTree = "<group>"; };
+		30FF5ED920931587002D7C77 /* DefaultTTLGetConfiguratorState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTTLGetConfiguratorState.swift; sourceTree = "<group>"; };
 		318B21D3C09027B98FF8F0C00493237E /* dtls1.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = dtls1.h; path = opensslIncludes/openssl/dtls1.h; sourceTree = "<group>"; };
 		33A14F6D5A6F0C6E186D4171A085D0AC /* Pods-nRFMeshProvision_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-nRFMeshProvision_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
 		35838742BE205531ABE0B5522DEA4F54 /* AccessMessageParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccessMessageParser.swift; sourceTree = "<group>"; };
@@ -329,6 +333,7 @@
 				99596FCB06E843CC0AA79B4D70FB7E8E /* SleepConfiguratorState.swift */,
 				30D40F832080D83100DC126F /* ModelAppBindConfiguratorState.swift */,
 				30686AF120876EB200DBEEA2 /* ModelPublicationSetConfiguratorState.swift */,
+				30FF5ED920931587002D7C77 /* DefaultTTLGetConfiguratorState.swift */,
 			);
 			path = ConfiguratorStates;
 			sourceTree = "<group>";
@@ -507,6 +512,7 @@
 				30D40F8C2080DEE600DC126F /* ModelAppBindStatusMessage.swift */,
 				30686AEF2087635400DBEEA2 /* ModelPublicationSetMessage.swift */,
 				30686AF3208771A600DBEEA2 /* ModelPublicationStatusMessage.swift */,
+				30FF5ED7209314DA002D7C77 /* DefaultTTLGetMessage.swift */,
 			);
 			path = AccessMessages;
 			sourceTree = "<group>";
@@ -882,6 +888,7 @@
 				9F221F9B88A4364E341B8FA54465AAE1 /* AccessMessagePDU.swift in Sources */,
 				BA9B1BC0D4091AA2F7A9276B27431503 /* AppKeyAddConfiguratorState.swift in Sources */,
 				30D40F822080CBDB00DC126F /* ModelAppBindMessage.swift in Sources */,
+				30FF5EDA20931587002D7C77 /* DefaultTTLGetConfiguratorState.swift in Sources */,
 				81971491D4A3F1B9708BA4181710CB07 /* AppKeyAddMessage.swift in Sources */,
 				F04EABF143487B7694AAC802789EFDCA /* AppKeyStatusMessage.swift in Sources */,
 				30D40F862080DD5500DC126F /* MessageStatusCodes.swift in Sources */,
@@ -903,6 +910,7 @@
 				CB430BA5A7D1F8C583AF7684D703CA74 /* DiscoveryConfiguratorState.swift in Sources */,
 				CBD8148EB05A095AC11425E6B8C2B74F /* DiscoveryProvisioningState.swift in Sources */,
 				672E29D62D477DB1F8AD4998FC08079A /* InputOutOfBoundActions.swift in Sources */,
+				30FF5ED8209314DA002D7C77 /* DefaultTTLGetMessage.swift in Sources */,
 				75E45EB6C07A700293B2B1AC4F58AE2E /* InviteProvisioningState.swift in Sources */,
 				051D9037C15538F5161DEB38BCDD1977 /* LowerTransportLayer.swift in Sources */,
 				35304939BAC356B98D33C2FD8FF3033B /* LowerTransportPDUParams.swift in Sources */,

--- a/Example/nRFMeshProvision/ViewControllers/NodeModelsView/ModelConfigurationView/ModelConfigurationTableViewController.swift
+++ b/Example/nRFMeshProvision/ViewControllers/NodeModelsView/ModelConfigurationView/ModelConfigurationTableViewController.swift
@@ -41,10 +41,10 @@ class ModelConfigurationTableViewController: UITableViewController, ProvisionedM
                                              onElementAddress: elementAddress,
                                              appKeyIndex: Data([0x00,0x00]),
                                              credentialFlag: false,
-                                             ttl: Data([0x04]),
-                                             period: Data([0x01]),
-                                             retransmitCount: Data([0x02]),
-                                             retransmitInterval: Data([0x05]),
+                                             ttl: Data([0xFF]),
+                                             period: Data([0x00]),
+                                             retransmitCount: Data([0x00]),
+                                             retransmitInterval: Data([0x00]),
                                              modelIdentifier: aModel,
                                              onDestinationAddress: nodeEntry.nodeUnicast!)
     }

--- a/nRFMeshProvision/Classes/Configurator/ConfiguratorStates/CompositionGetConfiguratorState.swift
+++ b/nRFMeshProvision/Classes/Configurator/ConfiguratorStates/CompositionGetConfiguratorState.swift
@@ -112,10 +112,10 @@ class CompositionGetConfiguratorState: NSObject, ConfiguratorStateProtocol {
                 if result is CompositionStatusMessage {
                     let compositionStatus = result as! CompositionStatusMessage
                     target.delegate?.receivedCompositionData(compositionStatus)
-                    //let appKeySetState = AppKeyAddConfiguratorState(withTargetProxyNode: target,
-                    //                                                destinationAddress: destinationAddress,
-                    //                                                andStateManager: stateManager)
-                    //target.switchToState(appKeySetState)
+                    let appKeySetState = AppKeyAddConfiguratorState(withTargetProxyNode: target,
+                                                                    destinationAddress: destinationAddress,
+                                                                    andStateManager: stateManager)
+                    target.switchToState(appKeySetState)
                 } else {
                     print("Ignoring non composition status message")
                 }

--- a/nRFMeshProvision/Classes/Configurator/ConfiguratorStates/ModelAppBindConfiguratorState.swift
+++ b/nRFMeshProvision/Classes/Configurator/ConfiguratorStates/ModelAppBindConfiguratorState.swift
@@ -31,7 +31,6 @@ class ModelAppBindConfiguratorState: NSObject, ConfiguratorStateProtocol {
         segmentedData = Data()
         stateManager = aStateManager
         destinationAddress = aDestinationAddress
-        networkLayer = NetworkLayer(withStateManager: stateManager)
         super.init()
         target.basePeripheral().delegate = self
         //If services and characteristics are already discovered, set them now
@@ -39,6 +38,10 @@ class ModelAppBindConfiguratorState: NSObject, ConfiguratorStateProtocol {
         proxyService            = discovery.proxyService
         dataInCharacteristic    = discovery.dataInCharacteristic
         dataOutCharacteristic   = discovery.dataOutCharacteristic
+
+        networkLayer = NetworkLayer(withStateManager: stateManager, andSegmentAcknowlegdement: { (ackData, delay) -> (Void) in
+            self.acknowlegeSegment(withAckData: ackData, withDelay: delay)
+        })
     }
     
     public func setBinding(elementAddress anElementAddress: Data,
@@ -81,8 +84,8 @@ class ModelAppBindConfiguratorState: NSObject, ConfiguratorStateProtocol {
                         header.append(Data([0x80])) //SAR cont.
                     }
                     var chunkData = Data(header)
-                    chunkData.append(data[aRange])
-                    segmentedProvisioningData.append(chunkData)
+                    chunkData.append(Data(data[aRange]))
+                    segmentedProvisioningData.append(Data(chunkData))
                 }
                 for aSegment in segmentedProvisioningData {
                     print("Sending model app bind segment: \(aSegment.hexString())")
@@ -97,7 +100,7 @@ class ModelAppBindConfiguratorState: NSObject, ConfiguratorStateProtocol {
             print("Secure beacon: \(incomingData.hexString())")
         } else {
             print("Incoming DPU: \(incomingData.hexString())")
-            let strippedOpcode = incomingData.dropFirst()
+            let strippedOpcode = Data(incomingData.dropFirst())
             if let result = networkLayer.incomingPDU(strippedOpcode) {
                 if result is ModelAppBindStatusMessage {
                     let modelKeyStatus = result as! ModelAppBindStatusMessage
@@ -130,6 +133,38 @@ class ModelAppBindConfiguratorState: NSObject, ConfiguratorStateProtocol {
         return ranges
     }
     
+    private func acknowlegeSegment(withAckData someData: Data, withDelay aDelay: DispatchTime) {
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() - DispatchTimeInterval.nanoseconds(Int(aDelay.uptimeNanoseconds))) {
+            print("Sending acknowledgement: \(someData.hexString())")
+            if someData.count <= self.target.basePeripheral().maximumWriteValueLength(for: .withoutResponse) {
+                self.target.basePeripheral().writeValue(someData, for: self.dataInCharacteristic, type: .withoutResponse)
+            } else {
+                print("Maximum write length is shorter than ACK PDU, will Segment")
+                var segmentedData = [Data]()
+                let dataToSegment = Data(someData.dropFirst()) //Remove old header as it's going to be added in SAR
+                let chunkRanges = self.calculateDataRanges(dataToSegment, withSize: 19)
+                for aRange in chunkRanges {
+                    var header = Data()
+                    let chunkIndex = chunkRanges.index(of: aRange)!
+                    if chunkIndex == 0 {
+                        header.append(Data([0x40])) //SAR start
+                    } else if chunkIndex == chunkRanges.count - 1 {
+                        header.append(Data([0xC0])) //SAR end
+                    } else {
+                        header.append(Data([0x80])) //SAR cont.
+                    }
+                    var chunkData = Data(header)
+                    chunkData.append(Data(dataToSegment[aRange]))
+                    segmentedData.append(Data(chunkData))
+                }
+                for aSegment in segmentedData {
+                    print("Sending Ack segment: \(aSegment.hexString())")
+                    self.target.basePeripheral().writeValue(aSegment, for: self.dataInCharacteristic, type: .withoutResponse)
+                }
+            }
+        }
+    }
+
     // MARK: - CBPeripheralDelegate
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
         //NOOP
@@ -139,24 +174,35 @@ class ModelAppBindConfiguratorState: NSObject, ConfiguratorStateProtocol {
         //NOOP
     }
     
+    var lastMessageType = 0xC0
+    
     func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        print("Cahrcateristic value updated: \(characteristic.value!.hexString())")
         //SAR handling
         if characteristic.value![0] & 0xC0 == 0x40 {
+            if lastMessageType == 0x40 {
+                //Drop repeated 0x40's
+                print("CMP:Reduntand SAR start, dropping")
+                segmentedData = Data()
+            }
+            lastMessageType = 0x40
             //Add message type header
-            segmentedData.append(characteristic.value![0] & 0x3F)
-            segmentedData.append(characteristic.value!.dropFirst())
+            segmentedData.append(Data([characteristic.value![0] & 0x3F]))
+            segmentedData.append(Data(characteristic.value!.dropFirst()))
         } else if characteristic.value![0] & 0xC0 == 0x80 {
+            lastMessageType = 0x80
             print("Segmented data cont")
-            segmentedData.append(characteristic.value!.dropFirst())
+            segmentedData.append(Data(characteristic.value!.dropFirst()))
         } else if characteristic.value![0] & 0xC0 == 0xC0 {
+            lastMessageType = 0xC0
             print("Segmented data end")
-            segmentedData.append(characteristic.value!.dropFirst())
+            segmentedData.append(Data(characteristic.value!.dropFirst()))
             print("Reassembled data!: \(segmentedData.hexString())")
             //Copy data and send it to NetworkLayer
             receivedData(incomingData: Data(segmentedData))
             segmentedData = Data()
         } else {
-            receivedData(incomingData: characteristic.value!)
+            receivedData(incomingData: Data(characteristic.value!))
         }
     }
     

--- a/nRFMeshProvision/Classes/Configurator/ConfiguratorStates/ModelPublicationSetConfiguratorState.swift
+++ b/nRFMeshProvision/Classes/Configurator/ConfiguratorStates/ModelPublicationSetConfiguratorState.swift
@@ -43,6 +43,7 @@ class ModelPublicationSetConfiguratorState: NSObject, ConfiguratorStateProtocol 
         proxyService            = discovery.proxyService
         dataInCharacteristic    = discovery.dataInCharacteristic
         dataOutCharacteristic   = discovery.dataOutCharacteristic
+
         networkLayer = NetworkLayer(withStateManager: aStateManager, andSegmentAcknowlegdement: { (ackData, delay) -> (Void) in
             self.acknowlegeSegment(withAckData: ackData, withDelay: delay)
         })
@@ -67,7 +68,7 @@ class ModelPublicationSetConfiguratorState: NSObject, ConfiguratorStateProtocol 
     }
     
     func humanReadableName() -> String {
-        return "Model AppKey Bind"
+        return "Model Publication Set"
     }
     
     func execute() {
@@ -104,7 +105,7 @@ class ModelPublicationSetConfiguratorState: NSObject, ConfiguratorStateProtocol 
                         header.append(Data([0x80])) //SAR cont.
                     }
                     var chunkData = Data(header)
-                    chunkData.append(data[aRange])
+                    chunkData.append(Data(data[aRange]))
                     segmentedProvisioningData.append(chunkData)
                 }
                 for aSegment in segmentedProvisioningData {
@@ -120,7 +121,7 @@ class ModelPublicationSetConfiguratorState: NSObject, ConfiguratorStateProtocol 
             print("Secure beacon: \(incomingData.hexString())")
         } else {
             print("incoming DPU: \(incomingData.hexString())")
-            let strippedOpcode = incomingData.dropFirst()
+            let strippedOpcode = Data(incomingData.dropFirst())
             if let result = networkLayer.incomingPDU(strippedOpcode) {
                 if result is ModelPublicationStatusMessage {
                     let publicationStatus = result as! ModelPublicationStatusMessage
@@ -131,18 +132,43 @@ class ModelPublicationSetConfiguratorState: NSObject, ConfiguratorStateProtocol 
             }
         }
     }
-    
+
     private func acknowlegeSegment(withAckData someData: Data, withDelay aDelay: DispatchTime) {
-        DispatchQueue.main.asyncAfter(deadline: aDelay) {
-            print("Ack segment: \(someData.hexString())")
-            self.target.basePeripheral().writeValue(someData, for: self.dataInCharacteristic, type: .withoutResponse)
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() - DispatchTimeInterval.nanoseconds(Int(aDelay.uptimeNanoseconds))) {
+            print("Sending acknowledgement: \(someData.hexString())")
+            if someData.count <= self.target.basePeripheral().maximumWriteValueLength(for: .withoutResponse) {
+                self.target.basePeripheral().writeValue(someData, for: self.dataInCharacteristic, type: .withoutResponse)
+            } else {
+                print("Maximum write length is shorter than ACK PDU, will Segment")
+                var segmentedData = [Data]()
+                let dataToSegment = Data(someData.dropFirst()) //Remove old header as it's going to be added in SAR
+                let chunkRanges = self.calculateDataRanges(dataToSegment, withSize: 19)
+                for aRange in chunkRanges {
+                    var header = Data()
+                    let chunkIndex = chunkRanges.index(of: aRange)!
+                    if chunkIndex == 0 {
+                        header.append(Data([0x40])) //SAR start
+                    } else if chunkIndex == chunkRanges.count - 1 {
+                        header.append(Data([0xC0])) //SAR end
+                    } else {
+                        header.append(Data([0x80])) //SAR cont.
+                    }
+                    var chunkData = Data(header)
+                    chunkData.append(Data(dataToSegment[aRange]))
+                    segmentedData.append(Data(chunkData))
+                }
+                for aSegment in segmentedData {
+                    print("Sending Ack segment: \(aSegment.hexString())")
+                    self.target.basePeripheral().writeValue(aSegment, for: self.dataInCharacteristic, type: .withoutResponse)
+                }
+            }
         }
     }
 
     private func calculateDataRanges(_ someData: Data, withSize aChunkSize: Int) -> [Range<Int>] {
         var totalLength = someData.count
         var ranges = [Range<Int>]()
-        
+
         var partIdx = 0
         while (totalLength > 0) {
             var range : Range<Int>
@@ -156,42 +182,52 @@ class ModelPublicationSetConfiguratorState: NSObject, ConfiguratorStateProtocol 
             ranges.append(range)
             partIdx += 1
         }
-        
+
         return ranges
     }
-    
+
     // MARK: - CBPeripheralDelegate
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
         //NOOP
     }
-    
+
     func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
         //NOOP
     }
-    
+
+    var lastMessageType = 0xC0
+
     func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        print("Cahrcateristic value updated: \(characteristic.value!.hexString())")
         //SAR handling
         if characteristic.value![0] & 0xC0 == 0x40 {
+            if lastMessageType == 0x40 {
+                //Drop repeated 0x40's
+                print("CMP:Reduntand SAR start, dropping")
+                segmentedData = Data()
+            }
+            lastMessageType = 0x40
             //Add message type header
-            segmentedData.append(characteristic.value![0] & 0x3F)
-            segmentedData.append(characteristic.value!.dropFirst())
+            segmentedData.append(Data([characteristic.value![0] & 0x3F]))
+            segmentedData.append(Data(characteristic.value!.dropFirst()))
         } else if characteristic.value![0] & 0xC0 == 0x80 {
+            lastMessageType = 0x80
             print("Segmented data cont")
-            segmentedData.append(characteristic.value!.dropFirst())
+            segmentedData.append(Data(characteristic.value!.dropFirst()))
         } else if characteristic.value![0] & 0xC0 == 0xC0 {
+            lastMessageType = 0xC0
             print("Segmented data end")
-            segmentedData.append(characteristic.value!.dropFirst())
+            segmentedData.append(Data(characteristic.value!.dropFirst()))
             print("Reassembled data!: \(segmentedData.hexString())")
             //Copy data and send it to NetworkLayer
             receivedData(incomingData: Data(segmentedData))
             segmentedData = Data()
         } else {
-            receivedData(incomingData: characteristic.value!)
+            receivedData(incomingData: Data(characteristic.value!))
         }
     }
-    
+
     func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
         print("Characteristic notification state changed")
     }
 }
-

--- a/nRFMeshProvision/Classes/MeshPDUs/AccessMessagePDU.swift
+++ b/nRFMeshProvision/Classes/MeshPDUs/AccessMessagePDU.swift
@@ -64,16 +64,16 @@ public struct AccessMessagePDU {
         var upperTransportParams: UpperTransportPDUParams!
 
         if nonce.type == .Device {
-            upperTransportParams = UpperTransportPDUParams(withPayload: opcode + payload, opcode: opcode, IVIndex: ivIndex, key: key!, ttl: ttl, seq: seq, src: src, dst: dst, nonce: nonce, ctl: false, afk: isAppKey, aid: Data([0x00]))
+            upperTransportParams = UpperTransportPDUParams(withPayload: Data(opcode + payload), opcode: opcode, IVIndex: ivIndex, key: key!, ttl: ttl, seq: seq, src: src, dst: dst, nonce: nonce, ctl: false, afk: isAppKey, aid: Data([0x00]))
         } else {
-            upperTransportParams = UpperTransportPDUParams(withPayload: opcode + payload, opcode: opcode, IVIndex: ivIndex, key: netKey, ttl: ttl, seq: seq, src: src, dst: dst, nonce: nonce, ctl: false, afk: isAppKey, aid: Data([0x00]))
+            upperTransportParams = UpperTransportPDUParams(withPayload: Data(opcode + payload), opcode: opcode, IVIndex: ivIndex, key: netKey, ttl: ttl, seq: seq, src: src, dst: dst, nonce: nonce, ctl: false, afk: isAppKey, aid: Data([0x00]))
         }
 
         let upperTransport = UpperTransportLayer(withParams: upperTransportParams)
 
         if let encryptedPDU = upperTransport.encrypt() {
             let isAppKeyData = isAppKey ? Data([0x01]) : Data([0x00])
-            let lowerTransportParams = LowerTransportPDUParams(withUpperTransportData: encryptedPDU, ttl: ttl, ctl: Data([0x00]), ivIndex: ivIndex, sequenceNumber: seq, sourceAddress: src, destinationAddress: dst, micSize: Data([0x00]), afk: isAppKeyData, aid: Data([0x00]), andOpcode: opcode)
+            let lowerTransportParams = LowerTransportPDUParams(withUpperTransportData: Data(encryptedPDU), ttl: ttl, ctl: Data([0x00]), ivIndex: ivIndex, sequenceNumber: seq, sourceAddress: src, destinationAddress: dst, micSize: Data([0x00]), afk: isAppKeyData, aid: Data([0x00]), andOpcode: opcode)
             let lowerTransport = LowerTransportLayer(withParams: lowerTransportParams)
             let networkLayer = NetworkLayer(withLowerTransportLayer: lowerTransport, andNetworkKey: netKey)
             return networkLayer.createPDU()

--- a/nRFMeshProvision/Classes/MeshPDUs/AccessMessages/AppKeyAddMessage.swift
+++ b/nRFMeshProvision/Classes/MeshPDUs/AccessMessages/AppKeyAddMessage.swift
@@ -24,12 +24,12 @@ public struct AppKeyAddMessage {
 //        payload.append(appKeyIndex[1])
         //First 3 octets are netkey and appkey indices
         //Next is the 16 octets of actual key data
-        payload.append(anAppKeyData)
+        payload.append(Data(anAppKeyData))
     }
    
     public func assemblePayload(withMeshState aState: MeshState, toAddress aDestinationAddress: Data) -> [Data]? {
         let deviceKey = aState.deviceKeyForUnicast(aDestinationAddress)
-        let accessMessage = AccessMessagePDU(withPayload: payload, opcode: opcode, deviceKey: deviceKey!, netKey: aState.netKey, seq: SequenceNumber(), ivIndex: aState.IVIndex, source: aState.unicastAddress, andDst: aDestinationAddress)
+        let accessMessage = AccessMessagePDU(withPayload: Data(payload), opcode: opcode, deviceKey: deviceKey!, netKey: aState.netKey, seq: SequenceNumber(), ivIndex: aState.IVIndex, source: aState.unicastAddress, andDst: aDestinationAddress)
         let networkPDU = accessMessage.assembleNetworkPDU()
         return networkPDU
     }

--- a/nRFMeshProvision/Classes/MeshPDUs/AccessMessages/DefaultTTLGetMessage.swift
+++ b/nRFMeshProvision/Classes/MeshPDUs/AccessMessages/DefaultTTLGetMessage.swift
@@ -1,0 +1,24 @@
+//
+//  DefaultTTLGetMessage.swift
+//  nRFMeshProvision
+//
+//  Created by Mostafa Berg on 27/04/2018.
+//
+
+import Foundation
+
+public struct DefaultTTLGetMessage {
+    var opcode: Data
+    var payload: Data
+    public init() {
+        opcode = Data([0x80, 0x0C])
+        payload = Data()
+    }
+    
+    public func assemblePayload(withMeshState aState: MeshState, toAddress aDestinationAddress: Data) -> [Data]? {
+        let deviceKey = aState.deviceKeyForUnicast(aDestinationAddress)
+        let accessMessage = AccessMessagePDU(withPayload: payload, opcode: opcode, deviceKey: deviceKey!, netKey: aState.netKey, seq: SequenceNumber(), ivIndex: aState.IVIndex, source: aState.unicastAddress, andDst: aDestinationAddress)
+        let networkPDU = accessMessage.assembleNetworkPDU()
+        return networkPDU
+    }
+}

--- a/nRFMeshProvision/Classes/Provisioner/ProvisioningStates/DiscoveryProvisioningState.swift
+++ b/nRFMeshProvision/Classes/Provisioner/ProvisioningStates/DiscoveryProvisioningState.swift
@@ -55,7 +55,7 @@ class DiscoveryProvisioningState: NSObject, ProvisioningStateProtocol {
                     dataInCharacteristic = aCharacteristic
                 } else if aCharacteristic.uuid == MeshCharacteristicProvisionDataOutUUID {
                     print("Discovered data out characteristic")
-                    dataOutCharacteristic = aCharacteristic
+                    dataOutCharacteristic  = aCharacteristic
                     peripheral.setNotifyValue(true, for: dataOutCharacteristic)
                 }
 

--- a/nRFMeshProvision/Classes/Transport/Network layer/NetworkLayer.swift
+++ b/nRFMeshProvision/Classes/Transport/Network layer/NetworkLayer.swift
@@ -57,7 +57,7 @@ public struct NetworkLayer {
         print("netMic: \(netMic.hexString())")
         print("Sequence: \(seq.hexString()), SRC: \(src.hexString()), ttl: \(ttl.hexString()), MICSize: \(micSize), encpduSz: \(encryptedNetworkPDU.count)")
         print("decrypted network PDU = \(decryptedNetworkPDU!.hexString())")
-        return self.lowerTransport.append(withIncomingPDU: decryptedNetworkPDU!, ctl: ctlData, ttl: ttl, src: src, dst: dst, IVIndex: ivIndex, andSEQ: seq)
+        return self.lowerTransport.append(withIncomingPDU: Data(decryptedNetworkPDU!), ctl: ctlData, ttl: ttl, src: src, dst: dst, IVIndex: ivIndex, andSEQ: seq)
     }
 
     public init(withLowerTransportLayer aLowerTransport: LowerTransportLayer, andNetworkKey aNetKey: Data) {

--- a/nRFMeshProvision/Classes/Transport/Network layer/NetworkLayer.swift
+++ b/nRFMeshProvision/Classes/Transport/Network layer/NetworkLayer.swift
@@ -22,8 +22,6 @@ public struct NetworkLayer {
         sslHelper = OpenSSLHelper()
         lowerTransport = LowerTransportLayer(withStateManager: aStateManager,
                                              andSegmentedAcknowlegdeMent: aSegmentAckBlock)
-        
-        
     }
 
     public mutating func incomingPDU(_ aPDU : Data) -> Any? {
@@ -93,7 +91,7 @@ public struct NetworkLayer {
         for aPDU in lowerPDU {
             var nonce: TransportNonce
 //            if lowerTransport.params.ctl == Data([0x01]) && lowerTransport.params.opcode == Data([0x00]) {
-////            if lowerTransport.params.ctl == Data([0x00]) {
+//            if lowerTransport.params.ctl == Data([0x00]) {
 //                nonce = TransportNonce(proxyNonceWithIVIndex: lowerTransport.params.ivIndex, seq: sequence.sequenceData(), src: lowerTransport.params.sourceAddress)
 //            } else {
                 nonce = TransportNonce(networkNonceWithIVIndex: lowerTransport.params.ivIndex, ctl: lowerTransport.params.ctl, ttl: lowerTransport.params.ttl, seq: sequence.sequenceData(), src: lowerTransport.params.sourceAddress)

--- a/nRFMeshProvision/Classes/Transport/TransportNonce.swift
+++ b/nRFMeshProvision/Classes/Transport/TransportNonce.swift
@@ -23,40 +23,40 @@ public struct TransportNonce {
         let typeData = Data([self.type.rawValue])
         let ctlTTL = Data([(aCTL[0] << 7) | (aTTL[0] & 0x7F)])
         var nonceData = Data()
-        nonceData.append(typeData)
-        nonceData.append(ctlTTL)
-        nonceData.append(aSeq)
-        nonceData.append(aSRC)
+        nonceData.append(Data(typeData))
+        nonceData.append(Data(ctlTTL))
+        nonceData.append(Data(aSeq))
+        nonceData.append(Data(aSRC))
         nonceData.append(Data([0x00, 0x00]))
-        nonceData.append(anIVIndex)
-        data = nonceData
+        nonceData.append(Data(anIVIndex))
+        data = Data(nonceData)
     }
 
     public init(appNonceWithIVIndex anIVIndex: Data, isSegmented isASegmentedMessage: Bool, seq aSeq: Data, src aSRC: Data, dst aDST: Data){
         type = .Application
         let typeData = Data([self.type.rawValue])
         var nonceData = Data()
-        nonceData.append(typeData)
+        nonceData.append(Data(typeData))
         if isASegmentedMessage {
             //ASZMIC is assumed to be 0 for this app
             //TODO: Support both 0 and 1 ASZMIC
             nonceData.append(Data([0x00]))
-            nonceData.append(aSeq)
+            nonceData.append(Data(aSeq))
         } else {
             nonceData.append(Data([0x00]))
-            nonceData.append(aSeq)
+            nonceData.append(Data(aSeq))
         }
-   nonceData.append(aSRC)
-        nonceData.append(aDST)
-        nonceData.append(anIVIndex)
-        data = nonceData
+        nonceData.append(Data(aSRC))
+        nonceData.append(Data(aDST))
+        nonceData.append(Data(anIVIndex))
+        data = Data(nonceData)
     }
    
     public init(deviceNonceWithIVIndex anIVIndex: Data, isSegmented isASegmentedMessage: Bool, szMIC aMICSize: UInt8, seq aSeq: Data, src aSRC: Data, dst aDST: Data) {
         type = .Device
         let typeData = Data([self.type.rawValue])
         var nonceData = Data()
-        nonceData.append(typeData)
+        nonceData.append(Data(typeData))
         if isASegmentedMessage {
             if aMICSize == 1 {
                 //64bit MIC
@@ -65,27 +65,27 @@ public struct TransportNonce {
                 //32bit MIC
                 nonceData.append(Data([0x00]))
             }
-            nonceData.append(aSeq)
+            nonceData.append(Data(aSeq))
         } else {
             nonceData.append(Data([0x00]))
-            nonceData.append(aSeq)
+            nonceData.append(Data(aSeq))
         }
-        nonceData.append(aSRC)
-        nonceData.append(aDST)
-        nonceData.append(anIVIndex)
-        data = nonceData
+        nonceData.append(Data(aSRC))
+        nonceData.append(Data(aDST))
+        nonceData.append(Data(anIVIndex))
+        data = Data(nonceData)
     }
    
     public init(proxyNonceWithIVIndex anIVIndex: Data, seq aSeq: Data, src aSRC: Data) {
         type = .Proxy
         let typeData = Data([self.type.rawValue])
         var nonceData = Data()
-        nonceData.append(typeData)
+        nonceData.append(Data(typeData))
         nonceData.append(Data([0x00])) //PAD 1
-        nonceData.append(aSeq)
-        nonceData.append(aSRC)
+        nonceData.append(Data(aSeq))
+        nonceData.append(Data(aSRC))
         nonceData.append(Data([0x00, 0x00])) //PAD 2
-        nonceData.append(anIVIndex)
+        nonceData.append(Data(anIVIndex))
         data = nonceData
     }
 }

--- a/nRFMeshProvision/Classes/Transport/Upper Transport Layer/UpperTransportLayer.swift
+++ b/nRFMeshProvision/Classes/Transport/Upper Transport Layer/UpperTransportLayer.swift
@@ -35,7 +35,7 @@ public struct UpperTransportLayer {
             let mic = aPDU[aPDU.count - micLen..<aPDU.count]
             if deviceKey != nil { //TODO: This check should not be needed
                 if let decryptedData = sslHelper.calculateDecryptedCCM(pduData, withKey: deviceKey!, nonce: deviceNonce.data, dataSize: dataSize, andMIC: mic) {
-                    decryptedPayload = decryptedData
+                    decryptedPayload = Data(decryptedData)
                 } else {
                     print("Decryption failed")
                 }


### PR DESCRIPTION
+Copy Data objects to preserve 0 indices on iOS versions below 11
+Added GATT Bearer SAR checks to assure that segments that are out of order are dropped
+Added segment caching to assure that incoming lower transport segments are not appended to the the current segment being Reassembled upon retransmission
+Fixes related to segmentation and reassembly,
This fixes the acknowledgement messages failing when they're longer than MTU size and are not segmented.
+This also adds Default TTL Get message support (Not accessible currently, but functional)
+Fixes a bug that caused an invalid state when a segmented message arrives over only one segment I.E: SegN=0x00 and SegO=0x00
causing the ack timer to have an unknown state.