### PR TITLE
Feature/mesh rejoin improvement

### DIFF
--- a/Example/nRFMeshProvision/Base.lproj/Main.storyboard
+++ b/Example/nRFMeshProvision/Base.lproj/Main.storyboard
@@ -546,6 +546,26 @@ provisioning and then configuring a device.</string>
                             <outlet property="delegate" destination="7BC-wy-MT8" id="aHs-OH-gfO"/>
                         </connections>
                     </tableView>
+                    <navigationItem key="navigationItem" title="Scanner" id="dXy-7Q-f8T">
+                        <barButtonItem key="rightBarButtonItem" style="plain" id="V3b-aS-AXg">
+                            <view key="customView" contentMode="scaleToFill" id="eGZ-2F-Xkm">
+                                <rect key="frame" x="276" y="0.0" width="83" height="44"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <subviews>
+                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="73W-Hm-dgN">
+                                        <rect key="frame" x="63" y="12" width="20" height="20"/>
+                                    </activityIndicatorView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="73W-Hm-dgN" firstAttribute="centerY" secondItem="eGZ-2F-Xkm" secondAttribute="centerY" id="4Nq-3t-c9G"/>
+                                    <constraint firstAttribute="trailing" secondItem="73W-Hm-dgN" secondAttribute="trailing" id="cfa-GC-Jwo"/>
+                                </constraints>
+                            </view>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="activityIndicator" destination="73W-Hm-dgN" id="aI3-Lw-8p1"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="1ux-tI-jQ9" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Example/nRFMeshProvision/Base.lproj/Main.storyboard
+++ b/Example/nRFMeshProvision/Base.lproj/Main.storyboard
@@ -72,7 +72,7 @@
                             <outlet property="delegate" destination="olZ-Yw-uFz" id="nNM-kL-SjO"/>
                         </connections>
                     </tableView>
-                    <tabBarItem key="tabBarItem" title="Add" image="ic_add_circle_outline" id="ING-Ye-G5c"/>
+                    <tabBarItem key="tabBarItem" title="Scanner" image="ic_add_circle_outline" id="ING-Ye-G5c"/>
                     <navigationItem key="navigationItem" title="Discovering Nodes" id="bVH-mR-mgf">
                         <barButtonItem key="backBarButtonItem" title="Back" id="PNv-B3-5GH"/>
                         <barButtonItem key="rightBarButtonItem" width="30" id="8yP-Q8-c5J">
@@ -205,7 +205,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="qB7-ud-fo9" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-241" y="588"/>
+            <point key="canvasLocation" x="-199" y="723"/>
         </scene>
         <!--App Keys-->
         <scene sceneID="aCw-tM-vxw">
@@ -285,7 +285,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="VPt-Te-jxw" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="478" y="587"/>
+            <point key="canvasLocation" x="521" y="723"/>
         </scene>
         <!--Network-->
         <scene sceneID="0oA-fM-gjl">
@@ -565,11 +565,48 @@ provisioning and then configuring a device.</string>
                     </navigationItem>
                     <connections>
                         <outlet property="activityIndicator" destination="73W-Hm-dgN" id="aI3-Lw-8p1"/>
+                        <outlet property="emptyScannerView" destination="wdq-dq-M7C" id="DPc-xK-nOu"/>
                     </connections>
                 </tableViewController>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wdq-dq-M7C" userLabel="EmpryScannerView">
+                    <rect key="frame" x="0.0" y="0.0" width="300" height="200"/>
+                    <subviews>
+                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_lan_36pt" translatesAutoresizingMaskIntoConstraints="NO" id="QNs-S2-5p6">
+                            <rect key="frame" x="138" y="20" width="24" height="24"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="24" id="9pp-cI-lUh"/>
+                                <constraint firstAttribute="width" constant="24" id="qcU-xX-jck"/>
+                            </constraints>
+                        </imageView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No Proxy nodes found" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="8" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BNU-Cj-ODJ">
+                            <rect key="frame" x="21" y="60" width="257" height="20"/>
+                            <fontDescription key="fontDescription" name="TrebuchetMS" family="Trebuchet MS" pointSize="17"/>
+                            <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="6" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YTg-SQ-uFK">
+                            <rect key="frame" x="21" y="92" width="257" height="83.666666666666686"/>
+                            <string key="text">If you can't find your proxy node, please ensure that  It's powered on, provisioned, and is a part of the current network  (must match network key)</string>
+                            <fontDescription key="fontDescription" name="TrebuchetMS" family="Trebuchet MS" pointSize="12"/>
+                            <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <constraints>
+                        <constraint firstItem="YTg-SQ-uFK" firstAttribute="leading" secondItem="wdq-dq-M7C" secondAttribute="leading" constant="21" id="0BJ-Kh-Zbv"/>
+                        <constraint firstItem="YTg-SQ-uFK" firstAttribute="top" secondItem="BNU-Cj-ODJ" secondAttribute="bottom" constant="12" id="8gz-CK-OqU"/>
+                        <constraint firstAttribute="trailing" secondItem="YTg-SQ-uFK" secondAttribute="trailing" constant="22" id="Fz9-e7-2jr"/>
+                        <constraint firstAttribute="trailing" secondItem="BNU-Cj-ODJ" secondAttribute="trailing" constant="22" id="HOi-h2-JZ3"/>
+                        <constraint firstItem="QNs-S2-5p6" firstAttribute="top" secondItem="wdq-dq-M7C" secondAttribute="top" constant="20" id="jEc-Hh-a2D"/>
+                        <constraint firstItem="BNU-Cj-ODJ" firstAttribute="leading" secondItem="wdq-dq-M7C" secondAttribute="leading" constant="21" id="jyc-0M-iMr"/>
+                        <constraint firstItem="QNs-S2-5p6" firstAttribute="centerX" secondItem="wdq-dq-M7C" secondAttribute="centerX" id="rHl-fV-9eA"/>
+                        <constraint firstItem="BNU-Cj-ODJ" firstAttribute="top" secondItem="QNs-S2-5p6" secondAttribute="bottom" constant="16" id="tVi-k4-6xs"/>
+                        <constraint firstAttribute="bottom" secondItem="YTg-SQ-uFK" secondAttribute="bottom" constant="24.333333333333314" id="x19-Q0-oew"/>
+                    </constraints>
+                </view>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="1ux-tI-jQ9" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-199" y="-188"/>
+            <point key="canvasLocation" x="-199" y="-51"/>
         </scene>
         <!--Configure-->
         <scene sceneID="1U7-Ze-AMA">

--- a/Example/nRFMeshProvision/ViewControllers/ReconnectionView/ProxyScannerCell.swift
+++ b/Example/nRFMeshProvision/ViewControllers/ReconnectionView/ProxyScannerCell.swift
@@ -16,7 +16,8 @@ class ProxyScannerCell: UITableViewCell {
     
     public func showNode(_ aNode: UnprovisionedMeshNode) {
         nodeName.text = aNode.nodeBLEName()
-        advertisementData.text = aNode.humanReadableNodeIdentifier()
+        advertisementData.text = nil //This is no longer needed
+        //advertisementData.text = aNode.humanReadableNodeIdentifier()
         if aNode.RSSI() != 127 {
             nodeRSSI.textColor = UIColor.black
             nodeRSSI.text = "\(aNode.RSSI()) dB"

--- a/Example/nRFMeshProvision/ViewControllers/ReconnectionView/ReconnectionViewController.swift
+++ b/Example/nRFMeshProvision/ViewControllers/ReconnectionView/ReconnectionViewController.swift
@@ -14,7 +14,8 @@ class ReconnectionViewController: UITableViewController {
 
     // MARK: - Outlets and actions
     @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
-
+    @IBOutlet var emptyScannerView: UIView!
+    
     // MARK: - Scanner Properties
     private var discoveredNodes = [UnprovisionedMeshNode]()
     private var centralManager: CBCentralManager!
@@ -29,13 +30,42 @@ class ReconnectionViewController: UITableViewController {
         mainView = aController
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.backgroundView = UIView(frame: self.view.frame)
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
         centralManager.stopScan()
         activityIndicator.stopAnimating()
         centralManager.delegate = originalCentraldelegate
+        super.viewWillDisappear(animated)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        self.hideEmptyView()
+        super.viewDidDisappear(animated)
     }
 
+    private func showEmptyView() {
+        if !tableView.backgroundView!.subviews.contains(emptyScannerView) {
+            tableView.isScrollEnabled = false
+            tableView.backgroundView?.addSubview(emptyScannerView)
+            let tableFrame          = tableView.frame
+            let horizontalSpacing   = CGFloat(15) //15 points
+            let width               = tableFrame.width - CGFloat(horizontalSpacing * 2)
+            let height              = CGFloat(250)
+            let verticalSpacing     = (tableFrame.size.height / 2) - height / 2.0
+            emptyScannerView.frame = CGRect(x: horizontalSpacing, y: verticalSpacing, width: width, height: height)
+        }
+    }
+    
+    private func hideEmptyView() {
+        if tableView.backgroundView == emptyScannerView {
+            tableView.isScrollEnabled = true
+            emptyScannerView.removeFromSuperview()
+        }
+    }
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
@@ -112,6 +142,11 @@ class ReconnectionViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if discoveredNodes.count == 0 {
+            showEmptyView()
+        } else {
+            hideEmptyView()
+        }
         return discoveredNodes.count
     }
 

--- a/nRFMeshProvision/Classes/Models/CompanyIdentifiers.swift
+++ b/nRFMeshProvision/Classes/Models/CompanyIdentifiers.swift
@@ -10,7 +10,7 @@ import Foundation
 // swiftlint:disable type_body_length file_length
 public struct CompanyIdentifiers {
     public var identifiersMap: [UInt16: String]
-    
+
     public init() {
         identifiersMap = [
         0x0000: "Ericsson Technology Licensing",


### PR DESCRIPTION
Mesh rejoin has the following features:

- Network identity is now validated, meaning only nodes of the same network will be displayed.
- Proxy scanner view now shows an empty state view instead of a blank screen
- Proxy scanner now displays status upon reconnection
- Proxy scanner now handles failures and disconnections when rejoining the mesh network
- Renamed Add to Scanner in the tab bar
