### PR TITLE
+Fixed bug with appkey index values above 1 causing failure to bind m…

### DIFF
--- a/Example/nRFMeshProvision/ViewControllers/NodeModelsView/ModelConfigurationView/ModelConfigurationTableViewController.swift
+++ b/Example/nRFMeshProvision/ViewControllers/NodeModelsView/ModelConfigurationView/ModelConfigurationTableViewController.swift
@@ -52,10 +52,13 @@ class ModelConfigurationTableViewController: UITableViewController, ProvisionedM
         let aModel = nodeEntry.elements![elementIdx].allSigAndVendorModels()[modelIdx]
         let unicast = nodeEntry.nodeUnicast!
         let elementAddress = Data([unicast[0], unicast[1] + UInt8(elementIdx)])
-        
+        guard let appKey = nodeEntry.appKeys.first else {
+            showstatusCodeAlert(withTitle: "AppKey was not found", andMessage: "This node did not have an appkey set in it's database entry.")
+            return
+        }
         targetNode.nodePublicationAddressSet(anAddress,
                                              onElementAddress: elementAddress,
-                                             appKeyIndex: Data([0x00,0x00]),
+                                             appKeyIndex: appKey,
                                              credentialFlag: false,
                                              ttl: Data([0xFF]),
                                              period: Data([0x00]),

--- a/nRFMeshProvision/Classes/MeshPDUs/AccessMessages/AppKeyAddMessage.swift
+++ b/nRFMeshProvision/Classes/MeshPDUs/AccessMessages/AppKeyAddMessage.swift
@@ -15,14 +15,11 @@ public struct AppKeyAddMessage {
         opcode = Data([0x00])
         payload = Data()
         //Data is packed, second Octet has 4 LSbs of netKeyINdex then 4 MSbs of AppKeyIndex
-        //Also all data is octet indexed, so the first 4 MSbs needs to be stripped from both values
+        //Also all data is octet indexed, so the first 4 MSbs needs to be stripped from both value
         payload.append(Data([netkeyIndex[1]]))
-        payload.append(Data([(appKeyIndex[1] & 0x0F) << 4 | (netkeyIndex[0] & 0x0F)]))
-        payload.append(Data([(appKeyIndex[0] & 0x0F) << 4 | (appKeyIndex[1] & 0xF0) >> 4]))
-//        payload.append(netkeyIndex[0] << 4 | netkeyIndex[1] >> 4)
-//        payload.append(netkeyIndex[1] << 4 | (appKeyIndex[0] & 0x0F) )
-//        payload.append(appKeyIndex[1])
-        //First 3 octets are netkey and appkey indices
+        payload.append(Data([(appKeyIndex[1] << 4) | (netkeyIndex[0] & 0x0F)]))
+        payload.append(Data([(appKeyIndex[0] << 4) | (appKeyIndex[1] >> 4)]))
+        //First 3 octets are netkey & appkey indices
         //Next is the 16 octets of actual key data
         payload.append(Data(anAppKeyData))
     }

--- a/nRFMeshProvision/Classes/MeshPDUs/AccessMessages/AppKeyStatusMessage.swift
+++ b/nRFMeshProvision/Classes/MeshPDUs/AccessMessages/AppKeyStatusMessage.swift
@@ -24,9 +24,9 @@ public struct AppKeyStatusMessage {
         appKeyIndex = Data()
 
         //Unpack netKey and appkey indices
-        netKeyIndex.append(aPayload[1] >> 4)
-        netKeyIndex.append(aPayload[1] << 4 | aPayload[2] >> 4)
-        appKeyIndex.append(aPayload[2] & 0x0F)
-        appKeyIndex.append(aPayload[3])
+        appKeyIndex.append(aPayload[1] >> 4)
+        appKeyIndex.append(aPayload[1] << 4 | aPayload[2] >> 4)
+        netKeyIndex.append(aPayload[2] & 0x0F)
+        netKeyIndex.append(aPayload[3])
     }
 }


### PR DESCRIPTION
…odels to app keys due to hardcoded value

+Fixed bug causing netkeyindex and appkeyindex values to be swapped in the appkey status message
+Added an alert and guard to warn against missing appkey in case of fautly mesh state database entry due to import/export or manual modification